### PR TITLE
Initialize Godot project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Godot editor generated directories
+.import/
+.godot/
+mono/
+
+# Exported builds
+bin/
+export/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Temporary files
+*.tmp

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,3 @@
+# Assets
+
+Place art, audio, and other asset files in this directory.

--- a/config/README.md
+++ b/config/README.md
@@ -1,0 +1,3 @@
+# Config
+
+This directory stores configuration files for the Garder-2d project.

--- a/project.godot
+++ b/project.godot
@@ -1,0 +1,12 @@
+; Engine configuration file.
+; This file was hand-edited due to the Godot editor being unavailable in the environment.
+
+config_version=5
+
+[application]
+config/name="Garder-2d"
+run/main_scene="res://scenes/Main.tscn"
+config/features=PackedStringArray("4.0")
+
+[rendering]
+renderer/rendering_method="forward_plus"

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://scripts/Main.gd" id="1_jv53d"]
+
+[node name="Main" type="Node2D"]
+script = ExtResource("1_jv53d")
+
+[node name="Label" type="Label" parent="."]
+text = "Welcome to Garder-2d!"

--- a/scripts/Main.gd
+++ b/scripts/Main.gd
@@ -1,0 +1,6 @@
+extends Node2D
+
+## Simple entry script for the starting scene.
+func _ready() -> void:
+    # Placeholder for initialization logic.
+    pass


### PR DESCRIPTION
## Summary
- add a Godot project configuration file with default settings and a main scene entry point
- scaffold base directories for scenes, scripts, assets, and config data with placeholder content
- add a starter scene and script plus a .gitignore tuned for Godot-generated artifacts

## Testing
- not run (Godot CLI not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cf0a32a158832d8016bd2a32464db8